### PR TITLE
Better I18N

### DIFF
--- a/res/layout/main.xml
+++ b/res/layout/main.xml
@@ -12,10 +12,10 @@
         android:layout_gravity="center_horizontal" />
 
     <TextView
-        android:id="@+id/helloText"
+        android:id="@+id/evaluating_url"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        android:text="@string/hello"
+        android:text="@string/evaluating"
         android:textSize="20sp" />
 
 </LinearLayout>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <string name="hello">Evaluating URL…</string>
     <string name="app_name">Short URL Evaluator</string>
-    <string name="couldnt_eval">Couldn\'t evaluate URL.</string>
-    <string name="evaluated_as">Evaluated as</string>
+    <string name="evaluating">Evaluating URL…</string>
+    <string name="evaluated_as">Evaluated as: %s</string>
+    <string name="couldnt_evaluate">Couldn\'t evaluate URL.</string>
 
 </resources>

--- a/src/com/github/nicolassmith/urlevaluator/UrlEvaluatorActivity.java
+++ b/src/com/github/nicolassmith/urlevaluator/UrlEvaluatorActivity.java
@@ -2,6 +2,7 @@ package com.github.nicolassmith.urlevaluator;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.content.res.Resources;
 import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
@@ -12,7 +13,6 @@ import android.widget.Toast;
 
 public class UrlEvaluatorActivity extends Activity implements EvaluatorTaskCaller {
 	/** This is the Activity that is called when a short URL intent is thrown by the Android OS **/
-	private static final String COLON_SPACE = ": ";
 	private static final String TAG = "UrlEvaluatorActivity";
 
 	@Override
@@ -33,13 +33,13 @@ public class UrlEvaluatorActivity extends Activity implements EvaluatorTaskCalle
 		/** called by the EvaluatorTask when the Task is done **/
 		if (output == null) {
 			// nothing returned
-			makeToast(getString(R.string.couldnt_eval)); // couldn't evaluate
+			makeToast(getString(R.string.couldnt_evaluate)); // couldn't evaluate
 			finish();
 			return;
 		}
 
 		// a URL was returned
-		String toastText = getString(R.string.evaluated_as) + COLON_SPACE + output;
+		String toastText = getString(R.string.evaluated_as, output);
 		makeToast(toastText);
 
 		updateText(output);
@@ -48,16 +48,17 @@ public class UrlEvaluatorActivity extends Activity implements EvaluatorTaskCalle
 		finish();
 	}
 
-
 	public void updateText(String newText) {
-		TextView helloText = (TextView) this.findViewById(R.id.helloText);
-		helloText.setText(newText);
+		TextView evaluatingUrl = (TextView) this.findViewById(R.id.evaluating_url);
+		evaluatingUrl.setText(newText);
 	}
+	
 	public void makeNewUriIntent(String uri){
 		Intent i = new Intent(Intent.ACTION_VIEW);
 		i.setData(Uri.parse(uri));
 		startActivity(i);
 	}
+
 	private void makeToast(String toastText) {
 		Toast.makeText(UrlEvaluatorActivity.this, toastText, Toast.LENGTH_LONG).show();
 	}


### PR DESCRIPTION
Uses a parameter instead of string concatenation when building the _“Evaluated as”_ label.
